### PR TITLE
Create SemVer releases based on PR tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag
+        uses: K-Phoen/semver-release-action@master
+        with:
+          release_branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By using the [K-Phoen/semver-release-action](https://github.com/K-Phoen/semver-release-action), GitHub releases (and tags) will automatically be created based on the label used in PRs (*patch*, *minor*, *major*)