### PR TITLE
add test coverage report and codecov support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,8 @@ jobs:
           go-version: '1.13'
 
       - run: make test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} #required

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -race $(PKGS)
+	go test -race $(PKGS) -coverprofile=coverage.txt -covermode=atomic
 
 .PHONY: tools
 tools:


### PR DESCRIPTION
Generate the test coverage so we can use codecov public plugin to see how the test coverage changes between PRs. All that needs to be done is adding the [CodeCov](https://github.com/apps/codecov) app, giving it right permission and creating a secret. 

Also, the awesome README badge could be added with:
`[![codecov](https://codecov.io/gh/voi-go/svc/branch/master/graph/badge.svg)](https://codecov.io/gh/voi-go/svc)`

😊 