### PR TITLE
Adding wait period to avoid gRPC deployment issues - PAY-276

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ worker fails to initialize itself, already initialized workers get terminated
 and then entire service is shut down. Initializing a worker **should not block**
 the service and should be quick as no deadline is given. After all workers have
 been initialized, the workers get asynchronously run (`worker.Run`). Worker's
-`Run` **should block**! 
+`Run` **should block**!
 
 4. **Shutdown** phase (`svc.Shutdown`): SVC now waits until either: (i) it
 got a _SigInt_, _SigTerm_, or _SigHup_, (ii) an error from a running worker, or
 (iii) that all workers have finished successfully. Then it asynchronously
 terminates all initialized workers (`worker.Terminate`). Failing to terminate a
 worker only logs that error, termination of other workers continues. This phase
-has a deadline of 15s by default, thus workers should terminate as quick and 
+has a deadline of 15s by default, thus workers should terminate as quick and
 graceful as possible.
 
 
@@ -57,10 +57,10 @@ The life-cycle is:
 
 1. **Instantiation** phase: A worker should get instantiated and then added to
 the service via `svc.AddWorker(name, worker)`. Each worker needs to have a
-unique name. 
+unique name.
 
 2. **Initialization** phase (`worker.Init`): A worker gets initialized and
-passed a named logger that it can keep to log throughout its life-time. 
+passed a named logger that it can keep to log throughout its life-time.
 Initialization must not block. If a worker fails to get initialized, SVC starts
 the shutdown routine.
 
@@ -68,7 +68,13 @@ the shutdown routine.
 task. When the task ends with an error, SVC immediately shuts down.
 
 4. **Termination** phase (`worker.Terminate`): A worker is asked to terminate
-within a given grace period. 
+within a given grace period. A wait period may also be provided to delay the
+termination of workers whilst an external system is refreshing their service
+target list. The grace period should be set as follows:
+`wait period + max in flight service request period + some buffer`. The `svc`
+grace period must always be greater than the wait period. When running in
+kubernetes the `terminationGracePeriodSeconds` must be greater than the `svc`
+grace period.
 
 
 ## Controller
@@ -181,10 +187,11 @@ opensource@voiapp.io.
 - [@drpytho](https://github.com/drpytho)
 - [@cvik](https://github.com/cvik)
 - [@K-Phoen](https://github.com/K-Phoen)
+- [@ronanbarrett](https://github.com/ronanbarrett)
 - [@zatte](https://github.com/zatte)
 
 #### I am missing?
-If you feel you should be on this list, create a PR to add yourself. 
+If you feel you should be on this list, create a PR to add yourself.
 
 ## License
 

--- a/options.go
+++ b/options.go
@@ -17,8 +17,7 @@ import (
 // Option defines SVC's option type.
 type Option func(*SVC) error
 
-// WithTerminationWaitPeriod is an option that sets the termination wait period
-// period.
+// WithTerminationWaitPeriod is an option that sets the termination wait period.
 func WithTerminationWaitPeriod(d time.Duration) Option {
 	return func(s *SVC) error {
 		s.TerminationWaitPeriod = d
@@ -27,8 +26,7 @@ func WithTerminationWaitPeriod(d time.Duration) Option {
 	}
 }
 
-// WithTerminationGracePeriod is an option that sets the termination grace period
-// period.
+// WithTerminationGracePeriod is an option that sets the termination grace period.
 func WithTerminationGracePeriod(d time.Duration) Option {
 	return func(s *SVC) error {
 		s.TerminationGracePeriod = d

--- a/options.go
+++ b/options.go
@@ -17,7 +17,17 @@ import (
 // Option defines SVC's option type.
 type Option func(*SVC) error
 
-// WithTerminationGracePeriod is an option that sets the termination grace
+// WithTerminationWaitPeriod is an option that sets the termination wait period
+// period.
+func WithTerminationWaitPeriod(d time.Duration) Option {
+	return func(s *SVC) error {
+		s.TerminationWaitPeriod = d
+
+		return nil
+	}
+}
+
+// WithTerminationGracePeriod is an option that sets the termination grace period
 // period.
 func WithTerminationGracePeriod(d time.Duration) Option {
 	return func(s *SVC) error {

--- a/svc.go
+++ b/svc.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	defaultTerminationGracePeriod = 15 * time.Second
+	defaultTerminationWaitPeriod  = 0 * time.Second
 )
 
 // SVC defines the worker life-cycle manager. It holds service metadata, router,
@@ -26,6 +27,7 @@ type SVC struct {
 	Router *http.ServeMux
 
 	TerminationGracePeriod time.Duration
+	TerminationWaitPeriod  time.Duration
 	signals                chan os.Signal
 
 	logger             *zap.Logger
@@ -48,6 +50,7 @@ func New(name, version string, opts ...Option) (*SVC, error) {
 		Router: http.NewServeMux(),
 
 		TerminationGracePeriod: defaultTerminationGracePeriod,
+		TerminationWaitPeriod:  defaultTerminationWaitPeriod,
 		signals:                make(chan os.Signal, 3),
 
 		workers:            map[string]Worker{},
@@ -165,6 +168,7 @@ func (s *SVC) terminateWorkers() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		time.Sleep(s.TerminationWaitPeriod)
 		for _, name := range s.workersInitialized {
 			defer func(name string) {
 				w := s.workers[name]


### PR DESCRIPTION
When deploying gRPC services we see an elevated error rate in clients (10% in experiments). Clients get both `NotAvailable` or `DeadlineExceeded` status codes. The root cause of this is when using SVC with Kubernetes headless services SVC is too eager to terminate services. Kubernetes headless services need ~30s before their target pod list is updated by performing a DNS refresh against kubedns. To fix this I have added a wait period before we attempt to shutdown services (the usual inflight handling). This time allows clients to update their pod target lists before pods start getting terminated. Using this wait period (35s for headless services) reduces the error rate to 0%.

Full details in PAY-276.